### PR TITLE
feat: add internal balance update endpoint with secret validation

### DIFF
--- a/backend/src/main/java/fr/fullstack/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/fr/fullstack/backend/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.GET, "/api/games/**", "/api/feature/**").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/internal/balance").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/backend/src/main/java/fr/fullstack/backend/controller/InternalBalanceController.java
+++ b/backend/src/main/java/fr/fullstack/backend/controller/InternalBalanceController.java
@@ -1,0 +1,34 @@
+package fr.fullstack.backend.controller;
+
+import fr.fullstack.backend.dto.InternalBalanceRequest;
+import fr.fullstack.backend.service.BalanceService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/internal/balance")
+public class InternalBalanceController {
+
+    private final BalanceService balanceService;
+    private final String internalSecret;
+
+    public InternalBalanceController(BalanceService balanceService,
+                                     @Value("${internal.secret}") String internalSecret) {
+        this.balanceService = balanceService;
+        this.internalSecret = internalSecret;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Boolean>> updateBalance(
+            @RequestHeader("X-Internal-Secret") String secret,
+            @RequestBody InternalBalanceRequest request) {
+        if (!internalSecret.equals(secret)) {
+            return ResponseEntity.status(403).build();
+        }
+        boolean success = balanceService.updateBalance(request.userid(), request.amount());
+        return ResponseEntity.ok(Map.of("success", success));
+    }
+}

--- a/backend/src/main/java/fr/fullstack/backend/dto/InternalBalanceRequest.java
+++ b/backend/src/main/java/fr/fullstack/backend/dto/InternalBalanceRequest.java
@@ -1,0 +1,3 @@
+package fr.fullstack.backend.dto;
+
+public record InternalBalanceRequest(Integer userid, Integer amount) {}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,3 +16,5 @@ spring.kafka.bootstrap-servers=kafka:9092
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
+internal.secret=${INTERNAL_SECRET:changeme}

--- a/backend/src/main/resources/openapi/swagger.yaml
+++ b/backend/src/main/resources/openapi/swagger.yaml
@@ -166,6 +166,46 @@ paths:
                 properties:
                   success:
                     type: boolean
+  /internal/balance:
+    post:
+      tags:
+        - Balance
+      summary: Mettre à jour le solde (usage interne uniquement)
+      description: Endpoint réservé aux appels serveur-à-serveur (ex. webhook Stripe). Protégé par le header `X-Internal-Secret` à la place du token OAuth2.
+      security: []
+      parameters:
+        - name: X-Internal-Secret
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - userid
+                - amount
+              properties:
+                userid:
+                  type: integer
+                amount:
+                  type: integer
+      responses:
+        '200':
+          description: Solde mis à jour
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+        '403':
+          description: Secret invalide
+
   /feature:
     get:
       tags:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - CLIENT_ID=ead85488-0ee1-41f9-9703-eac26103f5f4
       - REDIRECT_URI=http://localhost:4000/api/auth/callback
       - NODE_ENV=development
+      - INTERNAL_SECRET=${INTERNAL_SECRET:-webhook-internal-secret}
     volumes:
       # We mount the source code for hot-reloading in dev
       - ./frontend:/app
@@ -131,6 +132,7 @@ services:
       - SPRING_JPA_HIBERNATE_DDL_AUTO=update
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - AUTH_SERVICE_URL=http://auth:80
+      - INTERNAL_SECRET=${INTERNAL_SECRET:-webhook-internal-secret}
     depends_on:
       postgres-game:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,12 @@
-# Backend API URL
 BACKEND_URL=http://localhost:8080
+AUTH_URL=http://localhost:8000
+CLIENT_ID=ead85488-0ee1-41f9-9703-eac26103f5f4
+REDIRECT_URI=http://localhost:4000/api/auth/callback
 
-# Stripe (fill in CI via secrets, do not commit real values)
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_REPLACEME
-STRIPE_SECRET_KEY=sk_test_REPLACEME
-STRIPE_WEBHOOK_SECRET=whsec_REPLACEME
+# Stripe configuration
+STRIPE_WEBHOOK_SECRET=wh_replace_with_your_webhook_secret
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_replace_with_your_publishable_key
+STRIPE_SECRET_KEY=sk_replace_with_your_secret_key
+
+
+INTERNAL_SECRET=wh_replace_with_your_internal_secret

--- a/frontend/app/api/stripe/webhook/route.ts
+++ b/frontend/app/api/stripe/webhook/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8080";
+const INTERNAL_SECRET = process.env.INTERNAL_SECRET ?? "";
 
 export async function POST(req: NextRequest) {
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
@@ -48,10 +49,10 @@ export async function POST(req: NextRequest) {
       // Fund the wallet first so createOrder's balance check passes,
       // then the order creation deducts the same amount — net effect is zero.
       try {
-        const balanceRes = await fetch(`${BACKEND_URL}/api/balance`, {
+        const balanceRes = await fetch(`${BACKEND_URL}/api/internal/balance`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userid, amount: amountCents, payment_intent_id: paymentIntentId }),
+          headers: { "Content-Type": "application/json", "X-Internal-Secret": INTERNAL_SECRET },
+          body: JSON.stringify({ userid, amount: amountCents }),
         });
         if (!balanceRes.ok) {
           console.error("Webhook: backend POST /balance failed before order creation", balanceRes.status);
@@ -79,10 +80,10 @@ export async function POST(req: NextRequest) {
     } else {
       // Balance top-up
       try {
-        const res = await fetch(`${BACKEND_URL}/api/balance`, {
+        const res = await fetch(`${BACKEND_URL}/api/internal/balance`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ userid, amount: amountCents, payment_intent_id: paymentIntentId }),
+          headers: { "Content-Type": "application/json", "X-Internal-Secret": INTERNAL_SECRET },
+          body: JSON.stringify({ userid, amount: amountCents }),
         });
         if (!res.ok) {
           console.error("Webhook: backend POST /balance failed", res.status);


### PR DESCRIPTION
## Problem
The checkout.session.completed webhook was calling POST /api/balance server-to-server with no authentication token, causing a 401 from the backend and a 500 response to Stripe.

The backend's BalanceController is designed for user-initiated requests — it derives the user identity from the OAuth2 token via @AuthenticationPrincipal, not from the request body. Webhooks fire from Stripe's servers with no user session, so there is no token to provide.

## Solution
Add a dedicated internal endpoint POST /api/internal/balance for trusted server-to-server calls, protected by a shared secret (X-Internal-Secret header) instead of OAuth2. Spring Security permits this route without token introspection; the controller validates the secret itself.

## Changes
- InternalBalanceController — new POST /api/internal/balance endpoint; validates X-Internal-Secret, accepts {userid, amount} from request body
- InternalBalanceRequest — new DTO for the above
- SecurityConfig — permit /api/internal/balance so Spring doesn't block it before the controller runs
- application.properties — bind internal.secret from INTERNAL_SECRET env var
- docker-compose.yml — inject INTERNAL_SECRET into both frontend and backend services
- frontend/.env — add INTERNAL_SECRET for local development
- webhook/route.ts — call /api/internal/balance with the X-Internal-Secret header instead of the authenticated /api/balance endpoint